### PR TITLE
Update 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,7 +12,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>Interstitial Page for 1.USA.Gov Traffic</title>
 
-    <link rel="stylesheet" href="./assets/css/1usagov.css">
+    <link rel="stylesheet" href="../assets/css/1usagov.css">
 
   <link rel="canonical" href="https://www.usa.gov/" />
   <meta name="google" content="notranslate">
@@ -37,7 +37,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <div class="grid-container">
   <a id="english"></a>
         <div class="alert">
-          <img alt="alert" src="./assets/images/Alert_Icon.png">
+          <img alt="alert" src="../assets/images/Alert_Icon.png">
           <p>The 1.USA.gov URL shortening service is no longer supported and therefore can’t send you to the page you were looking for.</p>
         </div>
 
@@ -53,7 +53,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
           </div>
 
-          <img class="clkimg tgl" alt="clicked" src="./assets/images/Click_URL_Icon.png">
+          <img class="clkimg tgl" alt="clicked" src="../assets/images/Click_URL_Icon.png">
 
         <h1 class="tgl">If you clicked a 1.USA.gov URL</h1>
           <p>Here’s what you can try:</p>
@@ -68,13 +68,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
 
         <div class="created">
-          <img class="clkimg" alt="created URL" src="./assets/images/Create_URL_Icon.png">
+          <img class="clkimg" alt="created URL" src="../assets/images/Create_URL_Icon.png">
           <h2>If you created a 1.USA.gov URL</h2>
-          <p>The creation of new 1.usa.gov links hasn’t been possible for nearly three years. Please stop using 1.usa.gov URLs in your messages. If you need to shorten URLs using a government shortener, use <a href="https://go.usa.gov" title="go.usa.gov">Go.USA.gov.</a></p>
+          <p>The creation of new 1.usa.gov links hasn’t been possible for nearly three years. Please stop using 1.usa.gov URLs in your messages.</p>
         </div>
  <a id="spanish"></a>
         <div class="alertSp">
-          <img alt="alert" src="./assets/images/Alert_Icon.png">
+          <img alt="alert" src="../assets/images/Alert_Icon.png">
           <p>El servicio de 1.USA.gov para abreviar URLs ya no está disponible, por lo tanto, no puede enviarlo a la página que estaba buscando.
           </p>
         </div>
@@ -90,7 +90,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		          </div>
 	         </div>
 
-          <img class="clkimg" alt="clicked" src="./assets/images/Click_URL_Icon.png">
+          <img class="clkimg" alt="clicked" src="../assets/images/Click_URL_Icon.png">
           <h2>Si hizo clic en una dirección URL de 1.USA.gov</h2>
           <p>Puede intentar lo siguiente:</p>
           <ol>
@@ -104,9 +104,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
 
         <div class="createdSp">
-          <img class="clkimg" alt="created URL" src="./assets/images/Create_URL_Icon.png">
+          <img class="clkimg" alt="created URL" src="../assets/images/Create_URL_Icon.png">
           <h2>Si creó un URL en 1.USA.gov</h2>
-          <p>La creación de nuevos URLs con la herramienta de 1.USA.gov ha estado fuera de servicio por aproximadamente tres años. Por favor, no use los URLs de 1.USA.gov en sus mensajes. Si necesita abreviar URLs del Gobierno, utilice el servicio para abreviar URLs de <a href="https://go.usa.gov" title="go.usa.gov">Go.USA.gov</a>.</p>
+          <p>La creación de nuevos URLs con la herramienta de 1.USA.gov ha estado fuera de servicio por aproximadamente tres años. Por favor, no use los URLs de 1.USA.gov en sus mensajes.</p>
         </div>
     </div>
     </div>


### PR DESCRIPTION
Updated 404 page to remove reference to Go.USA.gov and update the path to images and stylesheets.